### PR TITLE
Numpy-ify the script, fix the -mjd flag

### DIFF
--- a/getper.py
+++ b/getper.py
@@ -3,7 +3,7 @@
 # Load some packages
 import numpy as np
 import scipy as sp
-#from scipy.stats import skew
+from scipy.stats import skew
 import matplotlib.pylab as plt
 import argparse
 import sys
@@ -15,7 +15,7 @@ parser.add_argument('-p1', type=float, dest='p1', help='set the lowest period (d
 parser.add_argument('-p2', type=float, dest='p2', help='set the lowest period (default: 10.0 seconds)', default=10.0)
 parser.add_argument('-days', dest='days', help='plot output in days rather than seconds (default: seconds)', default=False)
 parser.add_argument('-maxdiff', type=float, dest='maxdiff', help='maximum time difference to use (default: 3600.0 seconds)', default=3600.0)
-parser.add_argument('-mjd', dest='mjd', help='flag input times as MJD rather than seconds (default: false)', default=False)
+parser.add_argument('-mjd', dest='mjd', help='flag input times as MJD rather than seconds (default: false)', default=False, action = 'store_true')
 parser.add_argument('-pstep', type=float, dest='pstep', help='trial period step size in seconds (default: 0.001)', default=0.001)
 parser.add_argument('-tol', type=float, dest='tol', help='percentage tolerance in phase to count as a match (default: 10.0)', default=10.0)
 parser.add_argument('--version', action='version', version='%(prog)s 0.0.3')
@@ -24,12 +24,12 @@ args = parser.parse_args()
 ## Read in data
 # Read in barycentred times
 input_file = args.input_file
-print ("Reading input from file:",input_file)
+print("Reading input from file:",input_file)
 times = np.genfromtxt(input_file)
 times.sort()
 ntimes = np.size(times)
-print ("Total number of pulse times:",ntimes)
-print ("Total number of unique time differences:",ntimes*(ntimes-1)/2)
+print("Total number of pulse times:",ntimes)
+print("Total number of unique time differences:",ntimes*(ntimes-1)/2)
 # If input times in MJD, convert to seconds
 mjd = args.mjd
 if mjd:
@@ -39,39 +39,34 @@ if mjd:
 maxdiff = args.maxdiff
 #pstep = args.pstep*0.001
 pstep = args.pstep
-diffs = np.zeros(ntimes*ntimes)
-k = 0
-for i in range(0,ntimes):
-    for j in range(0,ntimes):
-        diff = times[j] - times[i]
-        if ( np.abs(diff) <= maxdiff):
-            if ( diff < 0.0 ):
-                diffs[k] = - diff
-            else:
-                diffs[k] = diff
-            k = k+1
-diffs.sort()
-diffs_unique = np.unique(diffs)
-print ("Total number of unique time differences less than ",maxdiff," seconds:",np.size(diffs_unique))
-print (diffs_unique)
+
+samples0 = np.array(times).reshape(-1, 1)
+samples1 = np.array(times).reshape(1, -1)
+
+delta = np.triu(np.abs(samples0 - samples1))
+diffs_unique = np.unique(delta).reshape(1,-1)
+
+print("Total number of unique time differences less than ",maxdiff," seconds:",np.size(diffs_unique))
+print(diffs_unique)
 
 ## Search period range
 p1 = args.p1
 p2 = args.p2
 #pstep = 0.001
 nsteps = int((p2 - p1)/pstep)
-print ("Searching from",p1,"to",p2,"in",nsteps,"steps")
+print("Searching from",p1,"to",p2,"in",nsteps,"steps")
 
 # Number of matches within 10 percent
 phase_tol = args.tol*0.01
 periods = np.zeros(nsteps)
-matches = np.zeros(nsteps)
-for i in range(0,nsteps):
-    periods[i] = p1+i*pstep
-    for j in range(0,np.size(diffs_unique)):
-        phase = (diffs_unique[j]/periods[i]) - int(diffs_unique[j]/periods[i])
-        if ( (phase < 0.5*phase_tol) or (phase > (1.0-0.5*phase_tol))):
-            matches[i] = matches[i] + 1
+
+periods = (p1 + np.arange(nsteps) * pstep).reshape(-1, 1)
+phase = (diffs_unique/periods) - (diffs_unique/periods).astype(int)
+
+locs = np.less(phase, 0.5 * phase_tol)
+locs += np.greater(phase, 1.0-0.5*phase_tol)
+
+matches = np.sum(locs, axis = 1)
 
 ## Plot the matches
 plt.ylabel("Number of matches")

--- a/getper.py
+++ b/getper.py
@@ -44,6 +44,7 @@ samples0 = np.array(times).reshape(-1, 1)
 samples1 = np.array(times).reshape(1, -1)
 
 delta = np.triu(np.abs(samples0 - samples1))
+delta = delta[delta < maxdiff]
 diffs_unique = np.unique(delta).reshape(1,-1)
 
 print("Total number of unique time differences less than ",maxdiff," seconds:",np.size(diffs_unique))

--- a/getper.py
+++ b/getper.py
@@ -3,7 +3,7 @@
 # Load some packages
 import numpy as np
 import scipy as sp
-from scipy.stats import skew
+#from scipy.stats import skew
 import matplotlib.pylab as plt
 import argparse
 import sys


### PR DESCRIPTION
Fix -mjd so that it doesn't need a value after it

Numpy base calculations significantly reduce the runtime, example on that target we're looking at with some extreme search values, `time python3 ./getper.py -i ./rough_secs -p1 1 -p2 60 -maxdiff 20000 -tol 5 -pstep 0.00001`

Old:
`218.83s user 1.48s system 99% cpu 3:41.51 total`

New:
`2.79s user 3.10s system 168% cpu 3.505 total`